### PR TITLE
Fix loading of modules by only their name

### DIFF
--- a/lib/importer.js
+++ b/lib/importer.js
@@ -13,7 +13,7 @@ function find(dir, file, callback) {
         var root = path.dirname(path.resolve(moduleDir, modulePath));
         var location;
         // if import is just a module name
-        if (file.split('/').length === 0) {
+        if (file.split('/').length === 1) {
             var json = require(path.resolve(moduleDir, modulePath));
             // look for "style" declaration in package.json
             if (json.style) {


### PR DESCRIPTION
Hey @lennym,

First of all, thanks for this module. Definitely going to to solve some workflow issues for me.

Tried this out in an isolated use case and it failed to load a module that had a "style" property in its `package.json`: `Error: File to import not found or unreadable:`

Tracked down the source of the error — the resulting array from splitting the path with "/" will be 1 instead of 0 if only the package name is used.