### PR TITLE
Include main property in the mix, if it's a css/sass/scss file

### DIFF
--- a/lib/importer.js
+++ b/lib/importer.js
@@ -21,6 +21,9 @@ function find(dir, file, callback) {
             // look for "style" declaration in package.json
             } else if (json.style) {
                 location = json.style;
+            // look for a css/sass/scss file in the "main" declaration in package.json
+            } else if (/\.(sa|c|sc)ss$/.test(json.main)) {
+                location = json.main;
             // otherwise assume ./styles.scss
             } else {
                 location = './styles';


### PR DESCRIPTION
Hey there! Unfortunately not all the package.json files have a style nor a sass property. My real use case is including [JohnAlbin/support-for], which is a normalize.scss's hard dependency. 
They do have their `main` package.json property set to the file to be included (and just to be safe, I check if it's a sass, scss, or a css file).
Cheers!