### PR TITLE
Added support for scoped packages

### DIFF
--- a/lib/importer.js
+++ b/lib/importer.js
@@ -4,8 +4,14 @@ var findup = require('findup'),
 var local = require('./local');
 
 function find(dir, file, callback) {
-    var name = file.split('/')[0],
-        modulePath = './node_modules/' + name + '/package.json';
+    var name;
+    if (file.split('/')[0][0] === '@') {
+        name = file.split('/').slice(0, 2).join('/');
+    } else {
+        name = file.split('/')[0];
+    }
+
+    var modulePath = './node_modules/' + name + '/package.json';
 
     findup(dir, modulePath, function (err, moduleDir) {
         if (err) { return callback(err); }
@@ -13,7 +19,7 @@ function find(dir, file, callback) {
         var root = path.dirname(path.resolve(moduleDir, modulePath));
         var location;
         // if import is just a module name
-        if (file.split('/').length === 1) {
+        if (file === name) {
             var json = require(path.resolve(moduleDir, modulePath));
             // look for "sass" declaration in package.json
             if (json.sass) {


### PR DESCRIPTION
As it stands, [scope packages](https://docs.npmjs.com/misc/scope) are not supported, which is a significant problem for groups using scopes to maintain either private or related packages. This PR adds the support for scoped packages by simply checking if the first text in the file descriptor is an "@" symbol.

I didn't see tests anywhere - let me know if I missed something. I PRed this as a result of needing it for my company's build, and it worked well in my use-case.