### PR TITLE
Allow relative paths in scoped packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,9 @@ build/Release
 
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
-node_modules
+/node_modules
+# Ignore node_modules installed during tests
+/test/test-cases/**/node_modules
 
 # npm debug logs
 npm-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+# npm debug logs
+npm-debug.log*
+
+# Vim swap files
+*.sw[pon]

--- a/lib/importer.js
+++ b/lib/importer.js
@@ -2,14 +2,16 @@ var findup = require('findup'),
     path = require('path');
 
 var local = require('./local');
-var resolve = require('./resolver')();
+var resolve = require('./resolver');
 
 function importer(url, file, done) {
     local(url, file, function (err, isLocal) {
         if (err || isLocal) {
             done({ file: url });
         } else {
-            done({ file: resolve(url) });
+            done({
+              file: resolve(url, file)
+            });
         }
     });
 }

--- a/lib/importer.js
+++ b/lib/importer.js
@@ -2,7 +2,7 @@ var findup = require('findup'),
     path = require('path');
 
 var local = require('./local');
-var resolve = require('./resolver').Resolver();
+var resolve = require('./resolver')();
 
 function importer(url, file, done) {
     local(url, file, function (err, isLocal) {

--- a/lib/importer.js
+++ b/lib/importer.js
@@ -2,71 +2,16 @@ var findup = require('findup'),
     path = require('path');
 
 var local = require('./local');
-
-function find(dir, file, callback) {
-    var name, isScoped = false;
-    if (file.split('/')[0][0] === '@') {
-        name = file.split('/').slice(0, 2).join('/');
-        isScoped = true;
-    } else {
-        name = file.split('/')[0];
-    }
-
-    var modulePath = './node_modules/' + name + '/package.json';
-
-    findup(dir, modulePath, function (err, moduleDir) {
-        if (err) { return callback(err); }
-
-        var root = path.dirname(path.resolve(moduleDir, modulePath));
-        var location;
-        // if import is just a module name
-        if (file === name) {
-            var json = require(path.resolve(moduleDir, modulePath));
-            // look for "sass" declaration in package.json
-            if (json.sass) {
-                location = json.sass;
-            // look for "style" declaration in package.json
-            } else if (json.style) {
-                location = json.style;
-            // look for a css/sass/scss file in the "main" declaration in package.json
-            } else if (/\.(sa|c|sc)ss$/.test(json.main)) {
-                location = json.main;
-            // otherwise assume ./styles.scss
-            } else {
-                location = './styles';
-            }
-        // if a full path is provided
-        } else {
-          if(isScoped) {
-            location = path.join('..', '..', file);
-          } else {
-            location = path.join('..', file);
-          }
-        }
-        callback(null, path.resolve(root, location));
-    });
-}
+var resolve = require('./resolver').Resolver();
 
 function importer(url, file, done) {
     local(url, file, function (err, isLocal) {
         if (err || isLocal) {
-            done({
-                file: url
-            });
+            done({ file: url });
         } else {
-            find(path.dirname(file), url, function (err, location) {
-                if (err) {
-                    done({
-                        file: url
-                    });
-                } else {
-                    done({
-                        file: location
-                    });
-                };
-            });
+            done({ file: resolve(url) });
         }
-    })
+    });
 }
 
 module.exports = importer;

--- a/lib/importer.js
+++ b/lib/importer.js
@@ -9,9 +9,7 @@ function importer(url, file, done) {
         if (err || isLocal) {
             done({ file: url });
         } else {
-            done({
-              file: resolve(url, file)
-            });
+            done({ file: resolve(url, file) });
         }
     });
 }

--- a/lib/importer.js
+++ b/lib/importer.js
@@ -9,14 +9,12 @@ function importer(url, file, done) {
         if (err || isLocal) {
             done({ file: url });
         } else {
-            resolve(url, file, function (err, path) {
-              if(err) {
-                done({ file: url });
-                return;
-              }
-
-              done({ file: path });
-            });
+            resolve(url, file)
+            .catch(function () { return url; })
+            .then(function (path) {
+              return { file: path };
+            })
+            .then(done);
         }
     });
 }

--- a/lib/importer.js
+++ b/lib/importer.js
@@ -9,7 +9,14 @@ function importer(url, file, done) {
         if (err || isLocal) {
             done({ file: url });
         } else {
-            done({ file: resolve(url, file) });
+            resolve(url, file, function (err, path) {
+              if(err) {
+                done({ file: url });
+                return;
+              }
+
+              done({ file: path });
+            });
         }
     });
 }

--- a/lib/importer.js
+++ b/lib/importer.js
@@ -4,9 +4,10 @@ var findup = require('findup'),
 var local = require('./local');
 
 function find(dir, file, callback) {
-    var name;
+    var name, isScoped = false;
     if (file.split('/')[0][0] === '@') {
         name = file.split('/').slice(0, 2).join('/');
+        isScoped = true;
     } else {
         name = file.split('/')[0];
     }
@@ -36,7 +37,11 @@ function find(dir, file, callback) {
             }
         // if a full path is provided
         } else {
-            location = path.join('../', file);
+          if(isScoped) {
+            location = path.join('..', '..', file);
+          } else {
+            location = path.join('..', file);
+          }
         }
         callback(null, path.resolve(root, location));
     });

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,13 +1,24 @@
 var Package = require('./resolver/package');
 var Import = require('./resolver/import');
+var nearestPackageRoot = require('./resolver/nearest-package-root');
 
-module.exports = function resolve(importUrl, refPath) {
+module.exports = function resolve(importUrl, referencePath, callback) {
     var _import = new Import(importUrl);
-    var _package = new Package(_import.packageName(), refPath);
 
-    if (_import.isEntrypoint()) {
-        return _package.fullPathToEntrypoint();
-    } else {
-        return _package.root(_import.specifiedFilePath());
-    }
+    Package.find(_import.packageName(), referencePath, function (err, _package) {
+      if(err) {
+          callback(err);
+          return;
+      }
+
+      var pathToImporterFile;
+
+      if (_import.isEntrypoint()) {
+          pathToImporterFile = _package.fullPathToEntrypoint();
+      } else {
+          pathToImporterFile = _package.root(_import.specifiedFilePath());
+      }
+
+      callback(null, pathToImporterFile);
+    });
 }

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -2,23 +2,16 @@ var Package = require('./resolver/package');
 var Import = require('./resolver/import');
 var nearestPackageRoot = require('./resolver/nearest-package-root');
 
-module.exports = function resolve(importUrl, referencePath, callback) {
+module.exports = function resolve(importUrl, importOriginPath) {
     var _import = new Import(importUrl);
 
-    Package.find(_import.packageName(), referencePath, function (err, _package) {
-      if(err) {
-          callback(err);
-          return;
-      }
+    return nearestPackageRoot(_import.packageName(), importOriginPath).then(function (packageRoot) {
+        var _package = new Package(packageRoot);
 
-      var pathToImporterFile;
-
-      if (_import.isEntrypoint()) {
-          pathToImporterFile = _package.fullPathToEntrypoint();
-      } else {
-          pathToImporterFile = _package.root(_import.specifiedFilePath());
-      }
-
-      callback(null, pathToImporterFile);
+        if (_import.isEntrypoint()) {
+            return _package.fullPathToEntrypoint();
+        } else {
+            return _package.root(_import.specifiedFilePath());
+        }
     });
 }

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -6,8 +6,8 @@ module.exports = function resolve(importUrl, refPath) {
     var _package = new Package(_import.packageName(), refPath);
 
     if (_import.isEntrypoint()) {
-      return _package.fullPathToEntrypoint();
+        return _package.fullPathToEntrypoint();
     } else {
-      return _package.root(_import.specifiedFilePath());
+        return _package.root(_import.specifiedFilePath());
     }
 }

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,19 +1,13 @@
 var Package = require('./resolver/package');
 var Import = require('./resolver/import');
 
-module.exports = function resolver(requireFn) {
-    /* Facilitate testing by allowing requireFn to be specified */
-    requireFn = (requireFn || require) ;
+module.exports = function resolve(importUrl, refPath) {
+    var _import = new Import(importUrl);
+    var _package = new Package(_import.packageName(), refPath);
 
-    return function resolve(sassImportPath) {
-        var _import = new Import(sassImportPath);
-        var _package = new Package(_import.packageName(), requireFn);
-
-        if (_import.isEntrypoint()) {
-            return _package.resolveEntrypoint();
-        } else {
-            return _package.safeResolve(_import.specifiedFilePath());
-        }
+    if (_import.isEntrypoint()) {
+      return _package.fullPathToEntrypoint();
+    } else {
+      return _package.root(_import.specifiedFilePath());
     }
 }
-

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,7 +1,7 @@
 var Package = require('./resolver/package');
 var Import = require('./resolver/import');
 
-exports.Resolver = function Resolver(requireFn) {
+module.exports = function resolver(requireFn) {
     /* Facilitate testing by allowing requireFn to be specified */
     requireFn = (requireFn || require) ;
 

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,0 +1,19 @@
+var Package = require('./resolver/package');
+var Import = require('./resolver/import');
+
+exports.Resolver = function Resolver(requireFn) {
+    /* Facilitate testing by allowing requireFn to be specified */
+    requireFn = (requireFn || require) ;
+
+    return function resolve(sassImportPath) {
+        var _import = new Import(sassImportPath);
+        var _package = new Package(_import.packageName(), requireFn);
+
+        if (_import.isEntrypoint()) {
+            return _package.resolveEntrypoint();
+        } else {
+            return _package.safeResolve(_import.specifiedFilePath());
+        }
+    }
+}
+

--- a/lib/resolver/import.js
+++ b/lib/resolver/import.js
@@ -29,6 +29,6 @@ Import.prototype.isEntrypoint = function isEntrypoint() {
     }
 };
 
-Import.prototype.specifiedFilePath = function specifiedFileName() {
+Import.prototype.specifiedFilePath = function specifiedFilePath() {
     return this.sassImportPath.slice(this.packageName().length);
 };

--- a/lib/resolver/import.js
+++ b/lib/resolver/import.js
@@ -1,0 +1,34 @@
+var path = require('path');
+
+module.exports = Import;
+
+function Import(sassImportPath) {
+    this.sassImportPath = sassImportPath;
+};
+
+Import.prototype.isScoped = function isScoped() {
+    return this.sassImportPath[0] === '@';
+};
+
+Import.prototype.packageName = function packageName() {
+    if (this.isScoped()) {
+        return this.sassImportPath.split(path.sep, 2).join(path.sep);
+    } else {
+        return this.sassImportPath.split(path.sep, 1)[0];
+    }
+};
+
+Import.prototype.isEntrypoint = function isEntrypoint() {
+    var safePathSplitPattern = new RegExp(path.sep + '.');
+    var pathSegmentCount = this.sassImportPath.split(safePathSplitPattern).length;
+
+    if (this.isScoped()) {
+        return pathSegmentCount === 2;
+    } else {
+        return pathSegmentCount === 1;
+    }
+};
+
+Import.prototype.specifiedFilePath = function specifiedFileName() {
+    return this.sassImportPath.slice(this.packageName().length);
+};

--- a/lib/resolver/import.js
+++ b/lib/resolver/import.js
@@ -1,26 +1,27 @@
 var path = require('path');
+var nearestPackageRoot = require('./nearest-package-root');
 
 module.exports = Import;
 
-function Import(sassImportPath) {
-    this.sassImportPath = sassImportPath;
-};
+function Import(importUrl) {
+    this.importUrl = importUrl;
+}
 
 Import.prototype.isScoped = function isScoped() {
-    return this.sassImportPath[0] === '@';
+    return this.importUrl[0] === '@';
 };
 
 Import.prototype.packageName = function packageName() {
     if (this.isScoped()) {
-        return this.sassImportPath.split(path.sep, 2).join(path.sep);
+        return this.importUrl.split(path.sep, 2).join(path.sep);
     } else {
-        return this.sassImportPath.split(path.sep, 1)[0];
+        return this.importUrl.split(path.sep, 1)[0];
     }
 };
 
 Import.prototype.isEntrypoint = function isEntrypoint() {
     var safePathSplitPattern = new RegExp(path.sep + '.');
-    var pathSegmentCount = this.sassImportPath.split(safePathSplitPattern).length;
+    var pathSegmentCount = this.importUrl.split(safePathSplitPattern).length;
 
     if (this.isScoped()) {
         return pathSegmentCount === 2;
@@ -30,5 +31,5 @@ Import.prototype.isEntrypoint = function isEntrypoint() {
 };
 
 Import.prototype.specifiedFilePath = function specifiedFilePath() {
-    return this.sassImportPath.slice(this.packageName().length);
+    return this.importUrl.slice(this.packageName().length);
 };

--- a/lib/resolver/nearest-package-root.js
+++ b/lib/resolver/nearest-package-root.js
@@ -4,14 +4,20 @@ var findup = require('findup');
 /**
  * @param {string} importOriginPath Path of file that made @import reference
  */
-module.exports = function nearestPackageRoot(importOriginPath, packageName) {
+module.exports = function nearestPackageRoot(packageName, importOriginPath, callback) {
     var pathToFind = path.join('node_modules', packageName, 'package.json');
-    var nearestPackageParent = findup.sync(path.dirname(importOriginPath), pathToFind);
-    var packageJSONLocation = path.join(
-        nearestPackageParent,
-        'node_modules',
-        packageName
-    );
 
-    return packageJSONLocation;
+    findup(path.dirname(importOriginPath), pathToFind, function (err, nearestPackageParent) {
+      if(err) {
+        callback(err);
+      }
+
+      var packageJSONLocation = path.join(
+          nearestPackageParent,
+          'node_modules',
+          packageName
+      );
+
+      callback(null, packageJSONLocation);
+    });
 };

--- a/lib/resolver/nearest-package-root.js
+++ b/lib/resolver/nearest-package-root.js
@@ -1,23 +1,29 @@
 var path = require('path');
 var findup = require('findup');
+var Promise = require('bluebird');
 
 /**
  * @param {string} importOriginPath Path of file that made @import reference
  */
-module.exports = function nearestPackageRoot(packageName, importOriginPath, callback) {
+module.exports = function nearestPackageRoot(packageName, importOriginPath) {
     var pathToFind = path.join('node_modules', packageName, 'package.json');
+    var dirnameOfImportOrigin = path.dirname(importOriginPath);
+    var promise, handleFoundPath;
 
-    findup(path.dirname(importOriginPath), pathToFind, function (err, nearestPackageParent) {
-      if(err) {
-        callback(err);
-      }
+    promise = new Promise(function (resolve, reject) {
+        handleFoundPath = function (err, nearestPackageParent) {
+            if(err) {
+                reject(err);
+                return;
+            }
 
-      var packageJSONLocation = path.join(
-          nearestPackageParent,
-          'node_modules',
-          packageName
-      );
+            var packageJSONLocation = path.join( nearestPackageParent, 'node_modules', packageName);
 
-      callback(null, packageJSONLocation);
+            resolve(packageJSONLocation);
+        };
     });
+
+    findup(dirnameOfImportOrigin, pathToFind, handleFoundPath);
+
+    return promise;
 };

--- a/lib/resolver/nearest-package-root.js
+++ b/lib/resolver/nearest-package-root.js
@@ -6,10 +6,11 @@ var findup = require('findup');
  */
 module.exports = function nearestPackageRoot(importOriginPath, packageName) {
     var pathToFind = path.join('node_modules', packageName, 'package.json');
+    var nearestPackageParent = findup.sync(path.dirname(importOriginPath), pathToFind);
     var packageJSONLocation = path.join(
-      findup.sync(path.dirname(importOriginPath), pathToFind),
-      'node_modules',
-      packageName
+        nearestPackageParent,
+        'node_modules',
+        packageName
     );
 
     return packageJSONLocation;

--- a/lib/resolver/nearest-package-root.js
+++ b/lib/resolver/nearest-package-root.js
@@ -1,0 +1,16 @@
+var path = require('path');
+var findup = require('findup');
+
+/**
+ * @param {string} importOriginPath Path of file that made @import reference
+ */
+module.exports = function nearestPackageRoot(importOriginPath, packageName) {
+    var pathToFind = path.join('node_modules', packageName, 'package.json');
+    var packageJSONLocation = path.join(
+      findup.sync(path.dirname(importOriginPath), pathToFind),
+      'node_modules',
+      packageName
+    );
+
+    return packageJSONLocation;
+};

--- a/lib/resolver/package.js
+++ b/lib/resolver/package.js
@@ -8,17 +8,6 @@ function Package(rootPath) {
     this.JSON = require(this.root('package.json'));
 };
 
-Package.find = function find(name, referencePath, callback) {
-    nearestPackageRoot(name, referencePath, function (err, path) {
-        if(err) {
-            callback(err);
-            return;
-        }
-
-        callback(null, new Package(path));
-    });
-};
-
 Package.prototype.fullPathToEntrypoint = function fullPathToEntrypoint() {
     return this.root(this.entrypoint());
 };

--- a/lib/resolver/package.js
+++ b/lib/resolver/package.js
@@ -1,46 +1,28 @@
 var path = require('path');
+var nearestPackageRoot = require('./nearest-package-root');
 
 module.exports = Package;
 
-function Package(name, requireFn) {
-    this.requireFn = requireFn;
-
-    this.path = path.join.bind(null, name);
+function Package(name, referencePath) {
+    this.root = path.join.bind(null, nearestPackageRoot(referencePath, name));
+    this.JSON = require(this.root('package.json'));
 };
 
-Package.prototype.json = function packageJSON() {
-    return this.requireFn(this.path('package.json'));
-};
-
-Package.prototype.resolve = function resolve(path) {
-    return this.requireFn.resolve(this.path(path));
-};
-
-Package.prototype.safeResolve = function safeResolve(potentiallyNonExistentPath) {
-    return path.join(this.dir(), potentiallyNonExistentPath);
-};
-
-Package.prototype.dir = function dir() {
-    return path.dirname(this.resolve('package.json'));
+Package.prototype.fullPathToEntrypoint = function fullPathToEntrypoint() {
+  return this.root(this.entrypoint());
 };
 
 Package.prototype.entrypoint = function entrypoint() {
-    var packageJson = this.json();
-
-    if (packageJson.sass) {
-        return packageJson.sass;
+    if (this.JSON.sass) {
+        return this.JSON.sass;
     // look for "style" declaration in package.json
-    } else if (packageJson.style) {
-        return packageJson.style;
+    } else if (this.JSON.style) {
+        return this.JSON.style;
     // look for a css/sass/scss file in the "main" declaration in package.json
-    } else if (/\.(sa|c|sc)ss$/.test(packageJson.main)) {
-        return packageJson.main;
+    } else if (/\.(sa|c|sc)ss$/.test(this.JSON.main)) {
+        return this.JSON.main;
     // otherwise assume ./styles.scss
     } else {
         return 'styles';
     }
-};
-
-Package.prototype.resolveEntrypoint = function resolveEntrypoint() {
-    return this.safeResolve(this.entrypoint());
 };

--- a/lib/resolver/package.js
+++ b/lib/resolver/package.js
@@ -1,0 +1,46 @@
+var path = require('path');
+
+module.exports = Package;
+
+function Package(name, requireFn) {
+    this.requireFn = requireFn;
+
+    this.path = path.join.bind(null, name);
+};
+
+Package.prototype.json = function packageJSON() {
+    return this.requireFn(this.path('package.json'));
+};
+
+Package.prototype.resolve = function resolve(path) {
+    return this.requireFn.resolve(this.path(path));
+};
+
+Package.prototype.safeResolve = function safeResolve(potentiallyNonExistentPath) {
+    return path.join(this.dir(), potentiallyNonExistentPath);
+};
+
+Package.prototype.dir = function dir() {
+    return path.dirname(this.resolve('package.json'));
+};
+
+Package.prototype.entrypoint = function entrypoint() {
+    var packageJson = this.json();
+
+    if (packageJson.sass) {
+        return packageJson.sass;
+    // look for "style" declaration in package.json
+    } else if (packageJson.style) {
+        return packageJson.style;
+    // look for a css/sass/scss file in the "main" declaration in package.json
+    } else if (/\.(sa|c|sc)ss$/.test(packageJson.main)) {
+        return packageJson.main;
+    // otherwise assume ./styles.scss
+    } else {
+        return 'styles';
+    }
+};
+
+Package.prototype.resolveEntrypoint = function resolveEntrypoint() {
+    return this.safeResolve(this.entrypoint());
+};

--- a/lib/resolver/package.js
+++ b/lib/resolver/package.js
@@ -3,9 +3,20 @@ var nearestPackageRoot = require('./nearest-package-root');
 
 module.exports = Package;
 
-function Package(name, referencePath) {
-    this.root = path.join.bind(null, nearestPackageRoot(referencePath, name));
+function Package(rootPath) {
+    this.root = path.join.bind(null, rootPath);
     this.JSON = require(this.root('package.json'));
+};
+
+Package.find = function find(name, referencePath, callback) {
+    nearestPackageRoot(name, referencePath, function (err, path) {
+        if(err) {
+            callback(err);
+            return;
+        }
+
+        callback(null, new Package(path));
+    });
 };
 
 Package.prototype.fullPathToEntrypoint = function fullPathToEntrypoint() {

--- a/lib/resolver/package.js
+++ b/lib/resolver/package.js
@@ -9,7 +9,7 @@ function Package(name, referencePath) {
 };
 
 Package.prototype.fullPathToEntrypoint = function fullPathToEntrypoint() {
-  return this.root(this.entrypoint());
+    return this.root(this.entrypoint());
 };
 
 Package.prototype.entrypoint = function entrypoint() {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "bin": "./bin/npm-sass",
   "scripts": {
-    "test": "mocha test/index.js"
+    "test": "NODE_PATH=$NODE_PATH:\"$(git rev-parse --show-toplevel)/test/fixtures/node_modules\" mocha test/index.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "unit-test-files": "test/units/*.js"
   },
   "scripts": {
-    "test": "mocha $npm_package_config_{unit_test_files,integration_test_files}",
+    "test": "mocha $npm_package_config_unit_test_files $npm_package_config_integration_test_files",
     "unit-test": "mocha $npm_package_config_unit_test_files",
     "integration-test": "mocha $npm_package_config_integration_test_files"
   },

--- a/package.json
+++ b/package.json
@@ -4,9 +4,14 @@
   "description": "sass compilation with npm aware include paths",
   "main": "index.js",
   "bin": "./bin/npm-sass",
+  "config": {
+    "integration-test-files": "test/index.js",
+    "unit-test-files": "test/units/*.js"
+  },
   "scripts": {
-    "test": "NODE_PATH=$NODE_PATH:\"$(git rev-parse --show-toplevel)/test/fixtures/node_modules\" mocha test/index.js",
-    "unit-test": "mocha test/units/*.js"
+    "test": "mocha $npm_package_config_{unit_test_files,integration_test_files}",
+    "unit-test": "mocha $npm_package_config_unit_test_files",
+    "integration-test": "mocha $npm_package_config_integration_test_files"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "css": "^2.2.1",
-    "mocha": "^3.0.2",
-    "sinon": "^1.17.6"
+    "mocha": "^3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "bin": "./bin/npm-sass",
   "scripts": {
-    "test": "NODE_PATH=$NODE_PATH:\"$(git rev-parse --show-toplevel)/test/fixtures/node_modules\" mocha test/index.js"
+    "test": "NODE_PATH=$NODE_PATH:\"$(git rev-parse --show-toplevel)/test/fixtures/node_modules\" mocha test/index.js",
+    "unit-test": "mocha test/units/*.js"
   },
   "repository": {
     "type": "git",
@@ -28,6 +29,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "css": "^2.2.1",
-    "mocha": "^3.0.2"
+    "mocha": "^3.0.2",
+    "sinon": "^1.17.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/lennym/npm-sass",
   "dependencies": {
     "argh": "^0.1.4",
+    "bluebird": "^3.4.6",
     "camelify": "0.0.2",
     "findup": "^0.1.5",
     "glob": "^6.0.1",

--- a/test/fixtures/package-test/node_modules/test-package/package.json
+++ b/test/fixtures/package-test/node_modules/test-package/package.json
@@ -1,0 +1,3 @@
+{
+  "sass": "test-package-entrypoint.scss"
+}

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "npm-sass-test-npm-modules",
-  "version": "0.0.0",
-  "description": "sass compilation with npm aware include paths",
-  "dependencies": {
-    "@lennym/npm-sass-test-sass": "0.0.0",
-    "npm-sass-test-sass": "0.0.0"
-  }
-}

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "npm-sass-test-npm-modules",
+  "version": "0.0.0",
+  "description": "sass compilation with npm aware include paths",
+  "dependencies": {
+    "@lennym/npm-sass-test-sass": "0.0.0",
+    "npm-sass-test-sass": "0.0.0"
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -9,14 +9,24 @@ const css = require('css');
 const root = path.resolve(__dirname, './test-cases');
 const cases = fs.readdirSync(root);
 
-before((done) => {
-  cp.exec('npm install', { cwd: path.resolve(__dirname, 'fixtures') }, (err) => {
-    done(err);
-  });
-});
-
 cases.forEach((test) => {
+  let hasPackageJson;
+
+  try {
+    hasPackageJson = require(path.resolve(root, test, './package.json'));
+  } catch (e) {}
+
   describe(test, () => {
+    before((done) => {
+      if (hasPackageJson) {
+        cp.exec('npm install', { cwd: path.resolve(root, test) }, (err) => {
+          done(err);
+        });
+      } else {
+        done();
+      }
+    });
+
     it('can compile from code without error', (done) => {
       sass(path.resolve(root, test, './index.scss'), (err, output) => {
         css.parse(output.css.toString());

--- a/test/index.js
+++ b/test/index.js
@@ -9,24 +9,14 @@ const css = require('css');
 const root = path.resolve(__dirname, './test-cases');
 const cases = fs.readdirSync(root);
 
+before((done) => {
+  cp.exec('npm install', { cwd: path.resolve(__dirname, 'fixtures') }, (err) => {
+    done(err);
+  });
+});
+
 cases.forEach((test) => {
-  let hasPackageJson;
-
-  try {
-    hasPackageJson = require(path.resolve(root, test, './package.json'));
-  } catch (e) {}
-
   describe(test, () => {
-    before((done) => {
-      if (hasPackageJson) {
-        cp.exec('npm install', { cwd: path.resolve(root, test) }, (err) => {
-          done(err);
-        });
-      } else {
-        done();
-      }
-    });
-
     it('can compile from code without error', (done) => {
       sass(path.resolve(root, test, './index.scss'), (err, output) => {
         css.parse(output.css.toString());

--- a/test/test-cases/scoped-packages-with-relative-path/index.scss
+++ b/test/test-cases/scoped-packages-with-relative-path/index.scss
@@ -1,0 +1,1 @@
+@import "@lennym/npm-sass-test-sass/child-file";

--- a/test/test-cases/scoped-packages-with-relative-path/package.json
+++ b/test/test-cases/scoped-packages-with-relative-path/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "npm-sass-test-npm-modules",
+  "version": "0.0.0",
+  "description": "sass compilation with npm aware include paths",
+  "dependencies": {
+    "@lennym/npm-sass-test-sass": "0.0.0"
+  }
+}

--- a/test/units/import-test.js
+++ b/test/units/import-test.js
@@ -1,0 +1,46 @@
+var Import = require('../../lib/resolver/import');
+var assert = require('assert');
+
+describe('Import', function () {
+  describe('#isScoped', function () {
+    it('returns true if package is scoped', function () {
+      var subject1 = new Import('@scoped/package');
+      var subject2 = new Import('non-scoped-package');
+
+      assert(subject1.isScoped());
+      assert(!subject2.isScoped());
+    });
+  });
+
+  describe('#packageName', function () {
+    it('returns the assumed package name', function () {
+      var subject1 = new Import('@scoped/package/nested-path');
+      var subject2 = new Import('non-scoped-package/nested-path');
+
+      assert.equal(subject1.packageName(), '@scoped/package');
+      assert.equal(subject2.packageName(), 'non-scoped-package');
+    });
+  });
+
+  describe('#isEntrypoint', function () {
+    it('returns true if the import is for the entrypoint', function () {
+      var subject1 = new Import('@scoped/package/nested-path');
+      var subject2 = new Import('@scoped/package');
+      var subject3 = new Import('non-scoped-package/nested-path');
+      var subject4 = new Import('non-scoped-package');
+
+      assert(!subject1.isEntrypoint());
+      assert(subject2.isEntrypoint());
+      assert(!subject3.isEntrypoint());
+      assert(subject4.isEntrypoint());
+    });
+  });
+
+  describe('#specifiedFilePath', function () {
+    it('returns the specified nested path', function () {
+      var subject = new Import('@scoped/package/nested-path1/nested-path2');
+
+      assert.equal(subject.specifiedFilePath(), '/nested-path1/nested-path2');
+    });
+  });
+});

--- a/test/units/nearest-package-root-test.js
+++ b/test/units/nearest-package-root-test.js
@@ -12,7 +12,7 @@ var fixturesPath = path.resolve.bind(null,
 describe('nearestPackageRoot', function () {
   it('finds the nearest module folder based on the import origin', function (done) {
     var sourcePath = fixturesPath('index.scss');
-    nearestPackageRoot('test-module', sourcePath, function (err, result) {
+    nearestPackageRoot('test-module', sourcePath).then(function (result) {
       assert.equal(result, fixturesPath('node_modules', 'test-module'));
       done();
     });
@@ -20,7 +20,7 @@ describe('nearestPackageRoot', function () {
 
   it('works with nested dependencies', function (done) {
     var sourcePath = fixturesPath('node_modules', 'test-module', 'index.scss');
-    nearestPackageRoot('nested-module', sourcePath, function (err, result) {
+    nearestPackageRoot('nested-module', sourcePath).then(function (result) {
       assert.equal(result, fixturesPath('node_modules', 'test-module', 'node_modules', 'nested-module'));
       done();
     });

--- a/test/units/nearest-package-root-test.js
+++ b/test/units/nearest-package-root-test.js
@@ -14,15 +14,17 @@ describe('nearestPackageRoot', function () {
     var sourcePath = fixturesPath('index.scss');
     nearestPackageRoot('test-module', sourcePath).then(function (result) {
       assert.equal(result, fixturesPath('node_modules', 'test-module'));
-      done();
-    });
+    })
+    .then(done)
+    .catch(done);
   });
 
   it('works with nested dependencies', function (done) {
     var sourcePath = fixturesPath('node_modules', 'test-module', 'index.scss');
     nearestPackageRoot('nested-module', sourcePath).then(function (result) {
       assert.equal(result, fixturesPath('node_modules', 'test-module', 'node_modules', 'nested-module'));
-      done();
-    });
+    })
+    .then(done)
+    .catch(done);
   });
 });

--- a/test/units/nearest-package-root-test.js
+++ b/test/units/nearest-package-root-test.js
@@ -10,13 +10,19 @@ var fixturesPath = path.resolve.bind(null,
 )
 
 describe('nearestPackageRoot', function () {
-  it('finds the nearest module folder based on the import origin', function () {
-    var result = nearestPackageRoot(fixturesPath('index.scss'), 'test-module');
+  it('finds the nearest module folder based on the import origin', function (done) {
+    var sourcePath = fixturesPath('index.scss');
+    nearestPackageRoot('test-module', sourcePath, function (err, result) {
+      assert.equal(result, fixturesPath('node_modules', 'test-module'));
+      done();
+    });
+  });
 
-    assert.equal(result, fixturesPath('node_modules', 'test-module'));
-
-    var result2 = nearestPackageRoot(fixturesPath('node_modules', 'test-module', 'index.scss'), 'nested-module');
-
-    assert.equal(result2, fixturesPath('node_modules', 'test-module', 'node_modules', 'nested-module'));
+  it('works with nested dependencies', function (done) {
+    var sourcePath = fixturesPath('node_modules', 'test-module', 'index.scss');
+    nearestPackageRoot('nested-module', sourcePath, function (err, result) {
+      assert.equal(result, fixturesPath('node_modules', 'test-module', 'node_modules', 'nested-module'));
+      done();
+    });
   });
 });

--- a/test/units/nearest-package-root-test.js
+++ b/test/units/nearest-package-root-test.js
@@ -1,0 +1,22 @@
+var nearestPackageRoot = require('../../lib/resolver/nearest-package-root');
+var assert = require('assert');
+var path = require('path');
+
+var fixturesPath = path.resolve.bind(null,
+  __dirname,
+  '..',
+  'fixtures',
+  'nearest-modules-root-fixtures'
+)
+
+describe('nearestPackageRoot', function () {
+  it('finds the nearest module folder based on the import origin', function () {
+    var result = nearestPackageRoot(fixturesPath('index.scss'), 'test-module');
+
+    assert.equal(result, fixturesPath('node_modules', 'test-module'));
+
+    var result2 = nearestPackageRoot(fixturesPath('node_modules', 'test-module', 'index.scss'), 'nested-module');
+
+    assert.equal(result2, fixturesPath('node_modules', 'test-module', 'node_modules', 'nested-module'));
+  });
+});

--- a/test/units/nearest-package-root-test.js
+++ b/test/units/nearest-package-root-test.js
@@ -6,7 +6,7 @@ var fixturesPath = path.resolve.bind(null,
   __dirname,
   '..',
   'fixtures',
-  'nearest-modules-root-fixtures'
+  'nearest-package-root-test'
 )
 
 describe('nearestPackageRoot', function () {

--- a/test/units/package-test.js
+++ b/test/units/package-test.js
@@ -1,0 +1,150 @@
+var Package = require('../../lib/resolver/package');
+var sinon = require('sinon');
+var assert = require('assert');
+
+describe('Package', function () {
+  var subject;
+
+  describe('#json', function () {
+    it('returns the package.json file for the package', function () {
+      var requireStub = sinon.stub();
+      var result;
+
+      requireStub.withArgs('test-package/package.json')
+        .returns('the package.json object');
+
+      subject = new Package('test-package', requireStub);
+
+      result = subject.json();
+
+      assert(requireStub.calledWith('test-package/package.json'));
+      assert.equal(result, 'the package.json object');
+    });
+  });
+
+  describe('#resolve', function () {
+    it('resolves a path that is local to the package', function () {
+      var requireMock = {
+        resolve: sinon.stub()
+      };
+
+      requireMock.resolve.withArgs('test-package/given-path').returns('npm resolved path');
+
+      var subject = new Package('test-package', requireMock);
+
+      var result = subject.resolve('given-path');
+
+      assert.equal(result, 'npm resolved path');
+      assert(requireMock.resolve.calledWith('test-package/given-path'));
+    });
+  });
+
+  describe('#safeResolve', function () {
+    it('resolves a path that is local to the package (but does not error out if it cannot find it)', function () {
+      var requireMock = {
+        resolve: sinon.stub()
+      };
+
+      requireMock.resolve.withArgs('test-package/package.json').returns('/a/b/c/test-package/package.json');
+
+      var subject = new Package('test-package', requireMock);
+
+      var result = subject.safeResolve('given-path');
+
+      assert.equal(result, '/a/b/c/test-package/given-path');
+    });
+  });
+
+  describe('#dir', function () {
+    it('returns the directory of the package', function () {
+      var requireMock = {
+        resolve: sinon.stub()
+      };
+
+      requireMock.resolve.withArgs('test-package/package.json').returns('/a/b/c/test-package/package.json');
+
+      var subject = new Package('test-package', requireMock);
+
+      var result = subject.dir();
+
+      assert.equal(result, '/a/b/c/test-package');
+    });
+  });
+
+  describe('#entrypoint', function () {
+    var requireStub
+
+    beforeEach(function () {
+      requireStub = sinon.stub();
+      requireStub.withArgs('test-package/package.json');
+    });
+
+    describe('sass', function () {
+      it('returns the entrypoint file', function () {
+        requireStub.returns({ sass: 'package-entrypoint' });
+
+        var subject = new Package('test-package', requireStub);
+
+        var result = subject.entrypoint();
+
+        assert.equal(result, 'package-entrypoint');
+      });
+    });
+
+    describe('style', function () {
+      it('returns the entrypoint file', function () {
+        requireStub.returns({ sass: null, style: 'package-entrypoint' });
+
+        var subject = new Package('test-package', requireStub);
+
+        var result = subject.entrypoint();
+
+        assert.equal(result, 'package-entrypoint');
+      });
+    });
+
+    describe('main', function () {
+      it('works with scss', function () {
+        requireStub.returns({ sass: null, style: null, main: 'index.scss' });
+
+        var subject = new Package('test-package', requireStub);
+
+        var result = subject.entrypoint();
+
+        assert.equal(result, 'index.scss');
+      });
+
+      it('works with css', function () {
+        requireStub.returns({ sass: null, style: null, main: 'index.css' });
+
+        var subject = new Package('test-package', requireStub);
+
+        var result = subject.entrypoint();
+
+        assert.equal(result, 'index.css');
+      });
+
+      it('works with sass', function () {
+        requireStub.returns({ sass: null, style: null, main: 'index.sass' });
+
+        var subject = new Package('test-package', requireStub);
+
+        var result = subject.entrypoint();
+
+        assert.equal(result, 'index.sass');
+      });
+    });
+
+    describe('not specified', function () {
+      it('falls back to styles', function () {
+        requireStub.returns({ sass: null, style: null, main: null });
+
+        var subject = new Package('test-package', requireStub);
+
+        var result = subject.entrypoint();
+
+        assert.equal(result, 'styles');
+      });
+    });
+  });
+});

--- a/test/units/package-test.js
+++ b/test/units/package-test.js
@@ -1,19 +1,18 @@
-var Package = require('../../lib/resolver/package');
 var sinon = require('sinon');
 var assert = require('assert');
+var path = require('path');
+
+var Package = require('../../lib/resolver/package');
 
 describe('Package', function () {
-  var subject;
-
   describe('#json', function () {
     it('returns the package.json file for the package', function () {
       var requireStub = sinon.stub();
+      var subject = new Package('test-package', requireStub);
       var result;
 
       requireStub.withArgs('test-package/package.json')
         .returns('the package.json object');
-
-      subject = new Package('test-package', requireStub);
 
       result = subject.json();
 
@@ -24,15 +23,13 @@ describe('Package', function () {
 
   describe('#resolve', function () {
     it('resolves a path that is local to the package', function () {
-      var requireMock = {
-        resolve: sinon.stub()
-      };
+      var requireMock = { resolve: sinon.stub() };
+      var subject = new Package('test-package', requireMock);
+      var result;
 
       requireMock.resolve.withArgs('test-package/given-path').returns('npm resolved path');
 
-      var subject = new Package('test-package', requireMock);
-
-      var result = subject.resolve('given-path');
+      result = subject.resolve('given-path');
 
       assert.equal(result, 'npm resolved path');
       assert(requireMock.resolve.calledWith('test-package/given-path'));
@@ -41,33 +38,31 @@ describe('Package', function () {
 
   describe('#safeResolve', function () {
     it('resolves a path that is local to the package (but does not error out if it cannot find it)', function () {
-      var requireMock = {
-        resolve: sinon.stub()
-      };
-
-      requireMock.resolve.withArgs('test-package/package.json').returns('/a/b/c/test-package/package.json');
-
+      var requireMock = { resolve: sinon.stub() };
       var subject = new Package('test-package', requireMock);
+      var result;
 
-      var result = subject.safeResolve('given-path');
+      requireMock.resolve.withArgs('test-package/package.json')
+        .returns(path.join('a', 'b', 'c', 'test-package', 'package.json'));
 
-      assert.equal(result, '/a/b/c/test-package/given-path');
+      result = subject.safeResolve('given-path');
+
+      assert.equal(result, path.join('a', 'b', 'c', 'test-package', 'given-path'));
     });
   });
 
   describe('#dir', function () {
     it('returns the directory of the package', function () {
-      var requireMock = {
-        resolve: sinon.stub()
-      };
-
-      requireMock.resolve.withArgs('test-package/package.json').returns('/a/b/c/test-package/package.json');
-
+      var requireMock = { resolve: sinon.stub() };
       var subject = new Package('test-package', requireMock);
+      var result;
 
-      var result = subject.dir();
+      requireMock.resolve.withArgs('test-package/package.json')
+        .returns(path.join('a', 'b', 'c', 'test-package', 'package.json'));
 
-      assert.equal(result, '/a/b/c/test-package');
+      result = subject.dir();
+
+      assert.equal(result, path.join('a', 'b', 'c', 'test-package'));
     });
   });
 

--- a/test/units/package-test.js
+++ b/test/units/package-test.js
@@ -14,7 +14,7 @@ describe('Package', function () {
     );
 
     it('returns the full path to the entrypoint file', function () {
-      var subject = new Package('test-package', fixturePath('index.scss'));
+      var subject = new Package(fixturePath('node_modules', 'test-package'));
       var result = subject.fullPathToEntrypoint();
 
       /* entrypoint file comes from test-package/package.json */

--- a/test/units/package-test.js
+++ b/test/units/package-test.js
@@ -1,4 +1,3 @@
-var sinon = require('sinon');
 var assert = require('assert');
 var path = require('path');
 

--- a/test/units/resolver-test.js
+++ b/test/units/resolver-test.js
@@ -14,24 +14,21 @@ var fixturePath = path.resolve.bind(
 
 describe('resolver', function () {
   describe('entrypoint import', function () {
-    it('resolves the entrypoint path', function () {
-      var result = resolve(
-        'test-package',
-        fixturePath('index.scss')
-      );
-
-      assert.equal(result, fixturePath('node_modules', 'test-package', 'test-package-entrypoint.scss'));
+    it('resolves the entrypoint path', function (done) {
+      resolve('test-package', fixturePath('index.scss'), function (err, result) {
+        assert.equal(result, fixturePath('node_modules', 'test-package', 'test-package-entrypoint.scss'));
+        done();
+      });
     });
   });
 
   describe('non entrypoint import', function () {
-    it('resolves the correct path', function () {
-      var result = resolve(
-        path.join('test-package', 'specific-file-in-package'),
-        fixturePath('index.scss')
-      );
-
-      assert.equal(result, fixturePath('node_modules', 'test-package', 'specific-file-in-package'));
+    it('resolves the correct path', function (done) {
+      var importPath = path.join('test-package', 'specific-file-in-package');
+      resolve(importPath, fixturePath('index.scss'), function (err, result) {
+        assert.equal(result, fixturePath('node_modules', 'test-package', 'specific-file-in-package'));
+        done();
+      });
     });
-  })
+  });
 });

--- a/test/units/resolver-test.js
+++ b/test/units/resolver-test.js
@@ -1,35 +1,37 @@
 var assert = require('assert');
 var path = require('path');
 
-var resolver = require('../../lib/resolver');
+var resolve = require('../../lib/resolver');
+
+var fixturePath = path.resolve.bind(
+  null,
+  __dirname,
+  '..',
+  'fixtures',
+  /* Re-use package-test fixutres */
+  'package-test'
+);
 
 describe('resolver', function () {
-  var fakeRequire = function (_sassImportPath) {
-    // Simulate package.json
-    return { sass: 'index.scss' };
-  };
-
-  fakeRequire.resolve = function (sassImportPath) {
-    return path.join('a', 'b', 'c', sassImportPath);
-  };
-
   describe('entrypoint import', function () {
     it('resolves the entrypoint path', function () {
-      var resolve = resolver(fakeRequire);
+      var result = resolve(
+        'test-package',
+        fixturePath('index.scss')
+      );
 
-      var result = resolve('package-name');
-
-      assert.equal(path.join('a', 'b', 'c', 'package-name', 'index.scss'), result);
+      assert.equal(result, fixturePath('node_modules', 'test-package', 'test-package-entrypoint.scss'));
     });
   });
 
   describe('non entrypoint import', function () {
     it('resolves the correct path', function () {
-      var resolve = resolver(fakeRequire);
+      var result = resolve(
+        path.join('test-package', 'specific-file-in-package'),
+        fixturePath('index.scss')
+      );
 
-      var result = resolve(path.join('package-name', 'specific-file-in-package'));
-
-      assert.equal(path.join('a', 'b', 'c', 'package-name', 'specific-file-in-package'), result);
+      assert.equal(result, fixturePath('node_modules', 'test-package', 'specific-file-in-package'));
     });
   })
 });

--- a/test/units/resolver-test.js
+++ b/test/units/resolver-test.js
@@ -15,20 +15,22 @@ var fixturePath = path.resolve.bind(
 describe('resolver', function () {
   describe('entrypoint import', function () {
     it('resolves the entrypoint path', function (done) {
-      resolve('test-package', fixturePath('index.scss'), function (err, result) {
+      resolve('test-package', fixturePath('index.scss')).then(function (result) {
         assert.equal(result, fixturePath('node_modules', 'test-package', 'test-package-entrypoint.scss'));
-        done();
-      });
+      })
+      .then(done)
+      .catch(done);
     });
   });
 
   describe('non entrypoint import', function () {
     it('resolves the correct path', function (done) {
       var importPath = path.join('test-package', 'specific-file-in-package');
-      resolve(importPath, fixturePath('index.scss'), function (err, result) {
+      resolve(importPath, fixturePath('index.scss')).then(function (result) {
         assert.equal(result, fixturePath('node_modules', 'test-package', 'specific-file-in-package'));
-        done();
-      });
+      })
+      .then(done)
+      .catch(done);
     });
   });
 });

--- a/test/units/resolver-test.js
+++ b/test/units/resolver-test.js
@@ -1,0 +1,35 @@
+var assert = require('assert');
+var path = require('path');
+
+var resolver = require('../../lib/resolver');
+
+describe('resolver', function () {
+  var fakeRequire = function (_sassImportPath) {
+    // Simulate package.json
+    return { sass: 'index.scss' };
+  };
+
+  fakeRequire.resolve = function (sassImportPath) {
+    return path.join('a', 'b', 'c', sassImportPath);
+  };
+
+  describe('entrypoint import', function () {
+    it('resolves the entrypoint path', function () {
+      var resolve = resolver(fakeRequire);
+
+      var result = resolve('package-name');
+
+      assert.equal(path.join('a', 'b', 'c', 'package-name', 'index.scss'), result);
+    });
+  });
+
+  describe('non entrypoint import', function () {
+    it('resolves the correct path', function () {
+      var resolve = resolver(fakeRequire);
+
+      var result = resolve('package-name/specific-file-in-package');
+
+      assert.equal(path.join('a', 'b', 'c', 'package-name', 'specific-file-in-package'), result);
+    });
+  })
+});

--- a/test/units/resolver-test.js
+++ b/test/units/resolver-test.js
@@ -27,7 +27,7 @@ describe('resolver', function () {
     it('resolves the correct path', function () {
       var resolve = resolver(fakeRequire);
 
-      var result = resolve('package-name/specific-file-in-package');
+      var result = resolve(path.join('package-name', 'specific-file-in-package'));
 
       assert.equal(path.join('a', 'b', 'c', 'package-name', 'specific-file-in-package'), result);
     });


### PR DESCRIPTION
Currently, a path such as `"@lennym/npm-sass-test-sass/child-file"` errors out. This makes it work(**referring to the first commit in this PR**), but I have concerns about the growing complexity of the `find` function.

I'm thinking about abstracting some of the package details such as `isScoped`, `name`
, and `entrypointLocation` (currently known as the `location` var) into a `Package` constructor in order to test each of these details in isolation while also simplifying the implementation of `find`.

What do you think @lennym?

--------------------

As I mentioned above, I gave a shot at refactoring the code to make it easier to test. I've yet to write unit tests for the logic but while digging into the code I found that a custom file resolution algorithm was being used. After some research, I found that node's own `require` function could be used to implement this. I like this because this is likely to stay compatible with node/npm future implementations. I tried to describe the changes in this PR 230e069

---------------------

Finally, I wrote unit tests for all of the new code. It is all runnable via `npm run unit-test`. 

I'm very glad to see that this tool exists, which makes me happy to contribute to it 😄 . @lennym let me know what you think, looking forward to hearing back.