### PR TITLE
Inline non-local css files

### DIFF
--- a/lib/importer.js
+++ b/lib/importer.js
@@ -19,7 +19,8 @@ module.exports = function (options) {
                 resolve(url, file)
                 .catch(function () { return url; })
                 .then(function (path) {
-                  return { file: path };
+                    path = path.replace(/\.css$/, '');
+                    return { file: path };
                 })
                 .then(done);
             }

--- a/lib/importer.js
+++ b/lib/importer.js
@@ -1,6 +1,3 @@
-var findup = require('findup'),
-    path = require('path');
-
 var local = require('./local');
 var resolve = require('./resolver');
 


### PR DESCRIPTION
If a module resolves its styles to a css file - as opposed to a sass file - then inline the css into the compiled output rather than adding an `import` statement into the css to attempt to resolve a local file.

This is achieved by passing node-sass the path without a file extension.