### PR TITLE
ability to resolve npm imports with ~ like webpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Example:
 ```sass
 @import "bootstrap";
 ```
+Or the Webpack syntax:
+
+```sass
+@import "~bootstrap";
+```
 
 This will import `./node_modules/bootstrap/dist/css/bootstrap.css` since this is [defined in bootstrap's package.json's `"style"` property](https://github.com/twbs/bootstrap/blob/master/package.json#L21)
 

--- a/lib/importer.js
+++ b/lib/importer.js
@@ -9,7 +9,8 @@ module.exports = function (options) {
         if (options.aliases && options.aliases[url]) {
             url = options.aliases[url];
         }
-        local(url, file, function (err, isLocal) {
+
+        local(url, file, function (url, err, isLocal) {
             if (err || isLocal) {
                 done({ file: url });
             } else {

--- a/lib/local.js
+++ b/lib/local.js
@@ -7,7 +7,9 @@ module.exports = function (url, file, done) {
     if (['.', path.sep].indexOf(url.substr(0, 1)) > -1) {
         return done(null, true);
     }
-
+    if(url[0] === '~'){
+	url = url.substring(1);
+    }
     // otherwise construct a glob to match possible relative file paths
     var basedir = path.dirname(file);
 
@@ -30,7 +32,7 @@ module.exports = function (url, file, done) {
 
     // test the constructed glob against the file system for possible matches
     glob(target, function (err, list) {
-        done(err, list.length);
+        done(url, err, list.length);
     });
 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-sass",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "sass compilation with npm aware include paths",
   "main": "index.js",
   "bin": "./bin/npm-sass",


### PR DESCRIPTION
Hi, thanks for the useful project! Because I have a codebase that has imports like this: `@import "~bootstrap";`, this pull request makes it possible to resolve it as just `bootstrap`. Hope it's useful! 
